### PR TITLE
Updates CoreDNS readme for kubebuilder 2.0

### DIFF
--- a/coredns/README.md
+++ b/coredns/README.md
@@ -7,30 +7,17 @@ A few differences so we can use go modules and [crane](https://github.com/google
 Created with kubebuilder:
 
 ```bash
-kubebuilder init --dep=false --domain=k8s.io --license apache2
+export KUBEBUILDER_ENABLE_PLUGINS=1
+kubebuilder init --dep=false --domain=k8s.io --license=apache2
 
-kubebuilder create api --controller=true --example=false --group=addons --kind=CoreDNS --make=false --namespaced=true --resource=true --version=v1alpha1
+kubebuilder create api --pattern addon --controller=true --example=false --group=addons --kind=CoreDNS --make=false --namespaced=true --resource=true --version=v1alpha1
 
 ```
 
-Switched to go modules:
+Run go mod vendor:
 
 ```bash
-export GO111MODULE=on
-go mod init sigs.k8s.io/cluster-addons/coredns
-
-# Insert our tools.go for extra dependencies
-cp ../tools.go tools.go
-
-go get -m k8s.io/client-go@v10.0.0
-go get -m k8s.io/api@kubernetes-1.13.5
-go get -m k8s.io/apimachinery@kubernetes-1.13.5
-go get -m k8s.io/apiserver@kubernetes-1.13.5
-go get -m k8s.io/apiextensions-apiserver@kubernetes-1.13.5
-
 go mod vendor
-
-rm Gopkg.toml
 ```
 
 Delete the test suites that are more checking that kubebuilder is working:
@@ -73,12 +60,8 @@ EOF
 Running the operator locally:
 
 ```bash
-export GOPATH=<go-path>
-go mod vendor
-make
-go build -o bin/manager sigs.k8s.io/cluster-addons/coredns/cmd/manager
 make install
-bin/manager
+make run
 ```
 We can see logs from the operator!
 

--- a/coredns/README.md
+++ b/coredns/README.md
@@ -8,7 +8,7 @@ Created with kubebuilder:
 
 ```bash
 export KUBEBUILDER_ENABLE_PLUGINS=1
-kubebuilder init --dep=false --domain=k8s.io --license=apache2
+kubebuilder init --fetch-dep=false --domain=k8s.io --license=apache2
 
 kubebuilder create api --pattern addon --controller=true --example=false --group=addons --kind=CoreDNS --make=false --namespaced=true --resource=true --version=v1alpha1
 


### PR DESCRIPTION
Some of the information in the readme is no longer relevant with kubebuilder 2.0. This pull request updates the readme.