### PR TITLE
[Trival] beta.kubernetes.io/os and beta.kubernetes.io/arch is already deprecated since v1.14, are targeted for removal in v1.18

### DIFF
--- a/coredns/channels/packages/coredns/1.3.1/coredns.yaml.base
+++ b/coredns/channels/packages/coredns/1.3.1/coredns.yaml.base
@@ -113,7 +113,7 @@ spec:
         - key: "CriticalAddonsOnly"
           operator: "Exists"
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
       - name: coredns
         image: k8s.gcr.io/coredns:1.3.1

--- a/coredns/channels/packages/coredns/1.3.1/manifest.yaml
+++ b/coredns/channels/packages/coredns/1.3.1/manifest.yaml
@@ -113,7 +113,7 @@ spec:
         - key: "CriticalAddonsOnly"
           operator: "Exists"
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
       - name: coredns
         image: k8s.gcr.io/coredns:1.3.1

--- a/dashboard/channels/packages/dashboard/2.0.0/manifest.yaml
+++ b/dashboard/channels/packages/dashboard/2.0.0/manifest.yaml
@@ -225,7 +225,7 @@ spec:
           emptyDir: {}
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master
@@ -292,7 +292,7 @@ spec:
             runAsGroup: 2001
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/dashboard/controllers/tests/patches-develop.out.yaml
+++ b/dashboard/controllers/tests/patches-develop.out.yaml
@@ -206,7 +206,7 @@ spec:
         - mountPath: /tmp
           name: tmp-volume
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       serviceAccountName: kubernetes-dashboard
       tolerations:
       - effect: NoSchedule
@@ -264,7 +264,7 @@ spec:
         - mountPath: /tmp
           name: tmp-volume
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       serviceAccountName: kubernetes-dashboard
       tolerations:
       - effect: NoSchedule

--- a/dashboard/controllers/tests/simple-develop.out.yaml
+++ b/dashboard/controllers/tests/simple-develop.out.yaml
@@ -206,7 +206,7 @@ spec:
         - mountPath: /tmp
           name: tmp-volume
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       serviceAccountName: kubernetes-dashboard
       tolerations:
       - effect: NoSchedule
@@ -264,7 +264,7 @@ spec:
         - mountPath: /tmp
           name: tmp-volume
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       serviceAccountName: kubernetes-dashboard
       tolerations:
       - effect: NoSchedule


### PR DESCRIPTION
fix https://github.com/kubernetes/kubernetes/issues/89477

/assign @stealthybox