### PR TITLE
Update kubebuilder annotations for metrics-server

### DIFF
--- a/metrics-server/Dockerfile
+++ b/metrics-server/Dockerfile
@@ -1,7 +1,14 @@
+FROM ubuntu:latest as kubectl
+RUN apt-get update
+RUN apt-get install -y curl
+RUN curl -fsSL https://dl.k8s.io/release/v1.13.4/bin/linux/amd64/kubectl > /usr/bin/kubectl
+RUN chmod a+rx /usr/bin/kubectl
+
 # Build the manager binary
 FROM golang:1.13 as builder
 
-WORKDIR /workspace
+# Copy in the go src
+WORKDIR /go/src/guestbook-operator
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -9,19 +16,18 @@ COPY go.sum go.sum
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-# Copy the go source
+COPY vendor/   vendor/
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+# Copy the operator and dependencies into a thin image
+FROM gcr.io/distroless/static:latest
 WORKDIR /
-COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
-
-ENTRYPOINT ["/manager"]
+COPY --from=builder /go/src/guestbook-operator/manager .
+COPY --from=kubectl /usr/bin/kubectl /usr/bin/kubectl
+COPY channels/ channels/
+ENTRYPOINT ["./manager"]

--- a/metrics-server/Dockerfile
+++ b/metrics-server/Dockerfile
@@ -8,7 +8,7 @@ RUN chmod a+rx /usr/bin/kubectl
 FROM golang:1.13 as builder
 
 # Copy in the go src
-WORKDIR /go/src/guestbook-operator
+WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -16,18 +16,19 @@ COPY go.sum go.sum
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-COPY vendor/   vendor/
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-# Copy the operator and dependencies into a thin image
-FROM gcr.io/distroless/static:latest
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /go/src/guestbook-operator/manager .
+COPY --from=builder /workspace/manager .
 COPY --from=kubectl /usr/bin/kubectl /usr/bin/kubectl
 COPY channels/ channels/
+USER nonroot:nonroot
 ENTRYPOINT ["./manager"]

--- a/metrics-server/Makefile
+++ b/metrics-server/Makefile
@@ -1,4 +1,3 @@
-
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
@@ -50,16 +49,12 @@ fmt:
 vet:
 	go vet ./...
 
-# Run go mod vendor
-vendor:
-	go mod vendor
-
 # Generate code
 generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths="./..."
 
 # Build the docker image
-docker-build: vendor test
+docker-build: test
 	docker build . -t ${IMG}
 
 # Push the docker image

--- a/metrics-server/Makefile
+++ b/metrics-server/Makefile
@@ -50,12 +50,16 @@ fmt:
 vet:
 	go vet ./...
 
+# Run go mod vendor
+vendor:
+	go mod vendor
+
 # Generate code
 generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths="./..."
 
 # Build the docker image
-docker-build: test
+docker-build: vendor test
 	docker build . -t ${IMG}
 
 # Push the docker image

--- a/metrics-server/config/crd/bases/addons.x-k8s.io_metricsservers.yaml
+++ b/metrics-server/config/crd/bases/addons.x-k8s.io_metricsservers.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: metricsservers.addons.x-k8s.io
 spec:

--- a/metrics-server/config/manager/kustomization.yaml
+++ b/metrics-server/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: controller
+  newTag: latest

--- a/metrics-server/config/rbac/role.yaml
+++ b/metrics-server/config/rbac/role.yaml
@@ -7,6 +7,61 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - nodes
+  - nodes/stats
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - list
+- apiGroups:
   - addons.x-k8s.io
   resources:
   - metricsservers
@@ -26,3 +81,52 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/metrics-server/controllers/metricsserver_controller.go
+++ b/metrics-server/controllers/metricsserver_controller.go
@@ -45,9 +45,6 @@ type MetricsServerReconciler struct {
 
 var _ reconcile.Reconciler = &MetricsServerReconciler{}
 
-// +kubebuilder:rbac:groups=addons.x-k8s.io,resources=metricsservers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=addons.x-k8s.io,resources=metricsservers/status,verbs=get;update;patch
-
 func (r *MetricsServerReconciler) setupReconciler(mgr ctrl.Manager) error {
 	labels := map[string]string{
 		"k8s-app": "metrics-server",
@@ -89,3 +86,19 @@ func (r *MetricsServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return nil
 }
+
+// for WithApplyPrune
+// +kubebuilder:rbac:groups=*,resources=*,verbs=list
+
+// +kubebuilder:rbac:groups=addons.x-k8s.io,resources=metricsservers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=addons.x-k8s.io,resources=metricsservers/status,verbs=get;update;patch
+
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups=apiregistration.k8s.io,resources=apiservices,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups="",resources=services;serviceaccounts;secrets,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups=apps;extensions,resources=deployments,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;delete;patch
+
+// +kubebuilder:rbac:groups="metrics.k8s.io",resources=pods;nodes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=pods;nodes;nodes/stats;namespaces,verbs=get;list;watch


### PR DESCRIPTION
This PR updates kubebuilder annotations in `metrics-server/controllers/metricsserver_controller.go`

Before this PR, metrics-server operator can't run in container.