### PR TITLE
Update kubebuilder annotations for dashboard

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,7 +1,14 @@
+FROM ubuntu:latest as kubectl
+RUN apt-get update
+RUN apt-get install -y curl
+RUN curl -fsSL https://dl.k8s.io/release/v1.13.4/bin/linux/amd64/kubectl > /usr/bin/kubectl
+RUN chmod a+rx /usr/bin/kubectl
+
 # Build the manager binary
 FROM golang:1.13 as builder
 
-WORKDIR /workspace
+# Copy in the go src
+WORKDIR /go/src/guestbook-operator
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -9,19 +16,18 @@ COPY go.sum go.sum
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-# Copy the go source
+COPY vendor/   vendor/
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+# Copy the operator and dependencies into a thin image
+FROM gcr.io/distroless/static:latest
 WORKDIR /
-COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
-
-ENTRYPOINT ["/manager"]
+COPY --from=builder /go/src/guestbook-operator/manager .
+COPY --from=kubectl /usr/bin/kubectl /usr/bin/kubectl
+COPY channels/ channels/
+ENTRYPOINT ["./manager"]

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -8,7 +8,7 @@ RUN chmod a+rx /usr/bin/kubectl
 FROM golang:1.13 as builder
 
 # Copy in the go src
-WORKDIR /go/src/guestbook-operator
+WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -16,18 +16,19 @@ COPY go.sum go.sum
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-COPY vendor/   vendor/
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-# Copy the operator and dependencies into a thin image
-FROM gcr.io/distroless/static:latest
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /go/src/guestbook-operator/manager .
+COPY --from=builder /workspace/manager .
 COPY --from=kubectl /usr/bin/kubectl /usr/bin/kubectl
 COPY channels/ channels/
+USER nonroot:nonroot
 ENTRYPOINT ["./manager"]

--- a/dashboard/Makefile
+++ b/dashboard/Makefile
@@ -1,4 +1,3 @@
-
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
@@ -38,6 +37,11 @@ deploy: manifests
 	cd config/manager && kustomize edit set image controller=${IMG}
 	kustomize build config/default | kubectl apply -f -
 
+# Teardown controller in the configured Kubernetes cluster in ~/.kube/config
+# This command does things that can't always re-run so the exit codes are ignored
+teardown: manifests
+	kustomize build config/default | kubectl delete -f - || true
+
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
@@ -50,12 +54,16 @@ fmt:
 vet:
 	go vet ./...
 
+# Run go mod vendor
+vendor:
+	go mod vendor
+
 # Generate code
 generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths="./..."
 
 # Build the docker image
-docker-build: test
+docker-build: vendor test
 	docker build . -t ${IMG}
 
 # Push the docker image

--- a/dashboard/Makefile
+++ b/dashboard/Makefile
@@ -54,16 +54,12 @@ fmt:
 vet:
 	go vet ./...
 
-# Run go mod vendor
-vendor:
-	go mod vendor
-
 # Generate code
 generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths="./..."
 
 # Build the docker image
-docker-build: vendor test
+docker-build: test
 	docker build . -t ${IMG}
 
 # Push the docker image

--- a/dashboard/config/manager/kustomization.yaml
+++ b/dashboard/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: controller
+  newTag: latest

--- a/dashboard/config/rbac/role.yaml
+++ b/dashboard/config/rbac/role.yaml
@@ -7,6 +7,51 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - proxy
+- apiGroups:
+  - ""
+  resources:
+  - services/proxy
+  verbs:
+  - get
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - list
+- apiGroups:
   - addons.x-k8s.io
   resources:
   - dashboards
@@ -26,3 +71,52 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - app.k8s.io
+  resources:
+  - applications
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/dashboard/controllers/dashboard_controller.go
+++ b/dashboard/controllers/dashboard_controller.go
@@ -62,9 +62,6 @@ func (r *DashboardReconciler) setupReconciler(mgr ctrl.Manager) error {
 	)
 }
 
-// +kubebuilder:rbac:groups=addons.x-k8s.io,resources=dashboards,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=addons.x-k8s.io,resources=dashboards/status,verbs=get;update;patch
-
 func (r *DashboardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err := r.setupReconciler(mgr); err != nil {
 		return err
@@ -89,3 +86,18 @@ func (r *DashboardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return nil
 }
+
+// for WithApplyPrune
+// +kubebuilder:rbac:groups=*,resources=*,verbs=list
+
+// +kubebuilder:rbac:groups=addons.k8s.io,resources=dashboards,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups=addons.k8s.io,resources=dashboards/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups="",resources=services;serviceaccounts;secrets;configmaps,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups=apps;extensions,resources=deployments,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups=app.k8s.io,resources=applications,verbs=get;list;watch;create;update;delete;patch
+
+// +kubebuilder:rbac:groups="metrics.k8s.io",resources=pods;nodes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=services,verbs=proxy
+// +kubebuilder:rbac:groups="",resources=services/proxy,verbs=get

--- a/dashboard/controllers/dashboard_controller.go
+++ b/dashboard/controllers/dashboard_controller.go
@@ -90,8 +90,8 @@ func (r *DashboardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // for WithApplyPrune
 // +kubebuilder:rbac:groups=*,resources=*,verbs=list
 
-// +kubebuilder:rbac:groups=addons.k8s.io,resources=dashboards,verbs=get;list;watch;create;update;delete;patch
-// +kubebuilder:rbac:groups=addons.k8s.io,resources=dashboards/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=addons.x-k8s.io,resources=dashboards,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups=addons.x-k8s.io,resources=dashboards/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups="",resources=services;serviceaccounts;secrets;configmaps,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;delete;patch


### PR DESCRIPTION
~This PR updates manifest for dashboard v2.0.0 because [v2.0.0 is released.](https://github.com/kubernetes/dashboard/releases/tag/v2.0.0)~

This PR fixes kubebuilder annotations in `dashboard_controller.go` to run in container.

**I've changed target of this PR.**
please see [my comment](https://github.com/kubernetes-sigs/cluster-addons/pull/55#issuecomment-640308176)