### PR TITLE
port kube-addon-manager v9.1.1 to Go as cluster-addons-bootstrap

### DIFF
--- a/bootstrap/.gitignore
+++ b/bootstrap/.gitignore
@@ -1,0 +1,2 @@
+cover.out
+cluster-addons-bootstrap

--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -1,0 +1,47 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+# Download a supported `kubectl` release for the target arch
+FROM --platform=$BUILDPLATFORM ubuntu:20.04 as kubectl
+ARG TARGETARCH
+RUN apt-get update
+RUN apt-get install -y curl
+RUN curl -fsSL https://dl.k8s.io/release/v1.17.4/bin/linux/${TARGETARCH}/kubectl > /usr/bin/kubectl
+RUN ! ldd /usr/bin/kubectl # Assert that the downloaded kubectl is statically linked
+RUN chmod a+rx /usr/bin/kubectl
+
+# Build the bootstrap binary
+FROM --platform=$BUILDPLATFORM golang:1.15 as builder
+
+# Copy the Go Modules manifests
+WORKDIR /go/src/bootstrap
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source files
+COPY main.go main.go
+COPY app/ app/
+
+# Build
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o cluster-addons-bootstrap main.go
+RUN ! ldd cluster-addons-bootstrap # Assert that the compiled bin is statically linked
+
+# Use distroless as minimal base image to package the bootstrap binary
+# See: https://github.com/GoogleContainerTools/distroless
+FROM gcr.io/distroless/static
+WORKDIR /
+COPY --from=builder /go/src/bootstrap/cluster-addons-bootstrap .
+COPY --from=kubectl /usr/bin/kubectl /usr/bin/kubectl
+
+ENTRYPOINT ["/cluster-addons-bootstrap"]

--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -1,0 +1,41 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DEV_TAG?=latest
+DEV_REPO?=${USER}/cluster-addons-bootstrap
+DEV_IMG?=$(DEV_REPO):$(DEV_TAG)
+IMG?=$(DEV_IMG)
+ARCH?=amd64
+
+.PHONY: build
+
+all: build
+
+build:
+	CGO_ENABLED=0 GOARCH=$(ARCH) GO111MODULE=on go build -o cluster-addons-bootstrap main.go
+
+docker-image:
+  # BuildKit is required for auto-population of `ARG TARGETARCH` during the build
+  # BuildKit requires Docker >= 18.09
+	DOCKER_BUILDKIT=1 docker build --platform=linux/$(ARCH) . -t $(IMG)
+
+fmt:
+	go fmt ./...
+
+vet:
+	go vet ./...
+
+test: fmt vet
+	go test ./... -coverprofile cover.out
+
+clean:
+	docker rmi -f $(IMG)

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -1,0 +1,24 @@
+### cluster-addons-bootstrap
+
+cluster-addons-bootstrap manages two classes of addons with given template files in
+`$ADDON_PATH` (default `/etc/kubernetes/addons/`).
+- Addons with label `addonmanager.kubernetes.io/mode=Reconcile` will be periodically
+reconciled. Direct manipulation to these addons through apiserver is discouraged because
+addon-manager will bring them back to the original state. In particular:
+	- Addon will be re-created if it is deleted.
+	- Addon will be reconfigured to the state given by the supplied fields in the template
+	file periodically.
+	- Addon will be deleted when its manifest file is deleted from the `$ADDON_PATH`.
+- Addons with label `addonmanager.kubernetes.io/mode=EnsureExists` will be checked for
+existence only. Users can edit these addons as they want. In particular:
+	- Addon will only be created/re-created with the given template file when there is no
+	instance of the resource with that name.
+	- Addon will not be deleted when the manifest file is deleted from the `$ADDON_PATH`.
+
+Notes:
+- Label `kubernetes.io/cluster-service=true` is deprecated (for this utility).
+In a future release,cluster-addons-bootstrap may not respect it anymore. Addons
+have this label but without `addonmanager.kubernetes.io/mode=EnsureExists` will be
+treated as "reconcile class addons" for now.
+- Resources under `$ADDON_PATH` need to have either one of these two labels.
+Otherwise it will be omitted.

--- a/bootstrap/app/addon-manager.go
+++ b/bootstrap/app/addon-manager.go
@@ -1,0 +1,306 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package app contains the application logic for the addon-manager.
+package app
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	defaultAdmissionControlsDir = "/etc/kubernetes/admission-controls"
+	systemNamespace             = "kube-system"
+	startAddonAttempts          = 100
+	startAddonRetryDelay        = 10 * time.Second
+
+	// Addons could use this label with two modes:
+	// - ADDON_MANAGER_LABEL=Reconcile
+	// - ADDON_MANAGER_LABEL=EnsureExists
+	addonManagerLabel = "addonmanager.kubernetes.io/mode"
+	modeReconcile     = "Reconcile"
+	modeEnsureExists  = "EnsureExists"
+
+	// This label is deprecated (only for Addon Manager). In future release
+	// addon-manager may not respect it anymore. Addons with
+	// CLUSTER_SERVICE_LABEL=true and without ADDON_MANAGER_LABEL=EnsureExists
+	// will be reconciled for now.
+	clusterServiceLabel = "kubernetes.io/cluster-service"
+)
+
+var (
+	// defaultKubectlPruneWhitelistResources is a list of resources whitelisted by default.
+	// This is currently the same with the default in:
+	// https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/apply/prune.go.
+	// To override the default list with other values, set
+	// KUBECTL_PRUNE_WHITELIST_OVERRIDE environment variable to space-separated
+	// names of resources to whitelist.
+	defaultKubectlPruneWhitelistResources = []string{
+		"core/v1/ConfigMap",
+		"core/v1/Endpoints",
+		"core/v1/Namespace",
+		"core/v1/PersistentVolumeClaim",
+		"core/v1/PersistentVolume",
+		"core/v1/Pod",
+		"core/v1/ReplicationController",
+		"core/v1/Secret",
+		"core/v1/Service",
+		"batch/v1/Job",
+		"batch/v1beta1/CronJob",
+		"apps/v1/DaemonSet",
+		"apps/v1/Deployment",
+		"apps/v1/ReplicaSet",
+		"apps/v1/StatefulSet",
+		"extensions/v1beta1/Ingress",
+	}
+	leaderRegexp = regexp.MustCompile(`^.*"holderIdentity":"([^"]*)".*`)
+)
+
+// addonManager has all of addon-manager's configurable parameters.
+type addonManager struct {
+	addonPath            string
+	admissionControlsDir string
+	checkInterval        time.Duration
+	hostname             string
+	kubectlOpts          string
+	kubectlPath          string
+	leaderElection       bool
+	pruneWhitelistFlags  []string
+
+	// stubbable for testing
+	kubectl func(stdout, stderr io.Writer, args ...string) error
+}
+
+func AddonManager(env func(key string) string) (*addonManager, error) {
+	am := &addonManager{
+		addonPath:            "/etc/kubernetes/addons",
+		admissionControlsDir: defaultAdmissionControlsDir,
+		checkInterval:        60 * time.Second,
+		hostname:             env("HOSTNAME"),
+		kubectlOpts:          env("KUBECTL_OPTS"),
+		kubectlPath:          "/usr/bin/kubectl",
+		leaderElection:       true,
+	}
+	am.kubectl = am.kubectlExec
+	if addonPath := env("ADDON_PATH"); addonPath != "" {
+		am.addonPath = addonPath
+	}
+	if kubectlPath := env("KUBECTL_BIN"); kubectlPath != "" {
+		am.kubectlPath = kubectlPath
+	}
+	if amle := env("ADDON_MANAGER_LEADER_ELECTION"); amle != "" {
+		b, err := strconv.ParseBool(amle)
+		if err != nil {
+			return nil, fmt.Errorf("error converting ADDON_MANAGER_LEADER_ELECTION value %q to bool: %v", amle, err)
+		}
+		am.leaderElection = b
+	}
+	if testIntervalSec := env("TEST_ADDON_CHECK_INTERVAL_SEC"); testIntervalSec != "" {
+		secs, err := strconv.ParseInt(testIntervalSec, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("error converting TEST_ADDON_CHECK_INTERVAL_SEC value %q to int64: %v", testIntervalSec, err)
+		}
+		am.checkInterval = time.Duration(secs) * time.Second
+	}
+	am.pruneWhitelistFlags = makePruneWhitelistFlags(env)
+	return am, nil
+}
+
+// makePruneWhitelistFlags generates kubectl prune-whitelist flags from provided environment variables.
+func makePruneWhitelistFlags(env func(key string) string) []string {
+	pw := defaultKubectlPruneWhitelistResources
+	if pwo := env("KUBECTL_PRUNE_WHITELIST_OVERRIDE"); pwo != "" {
+		pw = strings.Fields(pwo)
+	}
+	pwf := appendPruneWhitelistFlags(nil, pw)
+	pwf = appendPruneWhitelistFlags(pwf, strings.Fields(env("KUBECTL_EXTRA_PRUNE_WHITELIST")))
+	klog.Infof("== Generated kubectl prune whitelist flags: %s ==", strings.Join(pwf, " "))
+	return pwf
+}
+
+// appendPruneWhitelistFlags generates kubectl prune-whitelist flags from provided resource list.
+func appendPruneWhitelistFlags(pwf, resources []string) []string {
+	for _, resource := range resources {
+		pwf = append(pwf, "--prune-whitelist", resource)
+	}
+	return pwf
+}
+
+func (m *addonManager) Run() error {
+	m.waitForSystemServiceAccount()
+	if err := m.ensureDefaultAdmissionControlsObjects(); err != nil {
+		if os.IsNotExist(err) {
+			klog.Warningf("Admissions control object directory not found: %v", err)
+		} else {
+			klog.Errorf("Could not create admissions control objects: %v", err)
+		}
+	}
+	ticker := time.NewTicker(m.checkInterval)
+	for ; true; <-ticker.C { // Run immediately, then after every tick.
+		if !m.leaderElection || m.isLeader() {
+			m.ensureAddons()
+			m.reconcileAddons()
+		} else {
+			klog.Info("== Another addon-manager is acting as leader. Sleeping... ==")
+		}
+	}
+	return nil
+}
+
+func (m *addonManager) waitForSystemServiceAccount() {
+	var out, errOut bytes.Buffer
+	for {
+		err := m.kubectl(&out, &errOut, m.kubectlOpts, "get", "-n", systemNamespace, "serviceaccount", "default", "-o", "go-template={{with index .secrets 0}}{{.name}}{{end}}")
+		if errStr := errOut.String(); errStr != "" {
+			klog.Warning(errStr)
+		}
+		if err == nil && out.String() != "" {
+			return
+		}
+		out.Reset()
+		errOut.Reset()
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// Create admission_control objects if defined before any other addon services. If the limits
+// are defined in a namespace other than default, we should still create the limits for the
+// default namespace.
+func (m *addonManager) ensureDefaultAdmissionControlsObjects() error {
+	var out, errOut bytes.Buffer
+	return filepath.Walk(m.admissionControlsDir,
+		func(path string, _ os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			ext := filepath.Ext(path)
+			if ext == ".yaml" || ext == ".json" {
+				for attemptsRemaining := startAddonAttempts; attemptsRemaining > 0; attemptsRemaining-- {
+					err = m.kubectl(&out, &errOut, m.kubectlOpts, "--namespace=default", "apply", "-f", path)
+					filterLog(&out, "", klog.Info)
+					filterLog(&errOut, "", klog.Warning)
+					if err == nil {
+						klog.Infof("== Successfully started %s in namespace default ==", path)
+						return nil
+					}
+					klog.Warningf("== Failed to start %s in namespace default. %d tries remaining. ==", path, attemptsRemaining-1)
+					if attemptsRemaining > 1 {
+						time.Sleep(startAddonRetryDelay)
+					}
+				}
+			}
+			return err
+		})
+}
+
+// IsLeader returns whether this instance of addonManager should act as leader in a multi-master cluster.
+func (m *addonManager) isLeader() bool {
+	var out, errOut bytes.Buffer
+	klog.Info("== Determining addon-manager leader ==")
+	// TODO: Do a real leader election instead of piggybacking off of KCM
+	err := m.kubectl(&out, &errOut, m.kubectlOpts, "-n", systemNamespace, "get", "ep", "kube-controller-manager", "-o", `go-template={{index .metadata.annotations "control-plane.alpha.kubernetes.io/leader"}}`)
+	filterLog(&errOut, "", klog.Warning)
+	if err != nil {
+		// If the leader can't be positively established, assume that we're it
+		return true
+	}
+	holderIdentity := extractHolderIdentity(out.String())
+	return holderIdentity == "" || strings.HasPrefix(holderIdentity, m.hostname+"_")
+}
+
+func extractHolderIdentity(raw string) string {
+	captureGroups := leaderRegexp.FindStringSubmatch(raw)
+	if len(captureGroups) != 2 {
+		// A match yields one capture group (index 1)
+		return ""
+	}
+	return captureGroups[1]
+}
+
+func (m *addonManager) reconcileAddons() {
+	var out, errOut bytes.Buffer
+	klog.Info("== Reconciling with deprecated label ==")
+
+	// TODO: Remove the first command in future release.
+	// Adding this for backward compatibility. Old addons have CLUSTER_SERVICE_LABEL=true and don't have
+	// ADDON_MANAGER_LABEL=EnsureExists will still be reconciled.
+	m.kubectl(&out, &errOut, append([]string{
+		m.kubectlOpts,
+		"apply",
+		"-f", m.addonPath,
+		"--recursive",
+		"-l", clusterServiceLabel + "=true," + addonManagerLabel + "!=" + modeEnsureExists,
+		"--prune=true"},
+		m.pruneWhitelistFlags...)...)
+	// Filter out `configured` message to not noisily klog. `created`, `pruned` and errors will be logged.
+	filterLog(&out, "configured", klog.Info)
+	filterLog(&errOut, "configured", klog.Warning)
+	out.Reset()
+	errOut.Reset()
+	klog.Info("== Reconciling with addon-manager label ==")
+
+	m.kubectl(&out, &errOut, append([]string{
+		m.kubectlOpts,
+		"apply",
+		"-f", m.addonPath,
+		"--recursive",
+		"-l", clusterServiceLabel + "!=true," + addonManagerLabel + "=" + modeReconcile,
+		"--prune=true"},
+		m.pruneWhitelistFlags...)...)
+	filterLog(&out, "configured", klog.Info)
+	filterLog(&errOut, "configured", klog.Warning)
+	klog.Info("== Kubernetes addon reconcile completed ==")
+}
+
+func (m *addonManager) ensureAddons() {
+	var out bytes.Buffer
+	m.kubectl(&out, &out,
+		m.kubectlOpts,
+		"create",
+		"-f", m.addonPath,
+		"--recursive",
+		"-l", addonManagerLabel+"="+modeEnsureExists)
+	filterLog(&out, "AlreadyExists", klog.Info)
+	klog.Info("== Kubernetes addon ensure completed ==")
+}
+
+func (m *addonManager) kubectlExec(stdout, stderr io.Writer, args ...string) error {
+	cmd := exec.Command(m.kubectlPath, args...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+
+func filterLog(r io.Reader, doesNotContain string, logFunc func(...interface{})) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if doesNotContain == "" || !strings.Contains(line, doesNotContain) {
+			logFunc(line)
+		}
+	}
+}

--- a/bootstrap/app/addon-manager_test.go
+++ b/bootstrap/app/addon-manager_test.go
@@ -1,0 +1,549 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestIsLeader(t *testing.T) {
+	testHostname := "test-instance"
+	testKubectlOpts := "--kubeconfig=/some/dir/kubeconfig.json"
+	expectedKubectlArgs := []string{testKubectlOpts, "-n", "kube-system", "get", "ep", "kube-controller-manager", "-o", `go-template={{index .metadata.annotations "control-plane.alpha.kubernetes.io/leader"}}`}
+	tcs := []struct {
+		desc          string
+		kubectlOut    string
+		kubectlErrOut string
+		kubectlErr    error
+
+		expected bool
+	}{
+		{
+			desc:       "happy case, is leader",
+			kubectlOut: `{"holderIdentity":"test-instance_a6d5dd56-c545-11ea-b852-42010a800240","leaseDurationSeconds":15,"acquireTime":"2020-07-13T20:16:19Z","renewTime":"2020-07-16T16:48:51Z","leaderTransitions":0}`,
+			expected:   true,
+		},
+		{
+			desc:       "happy case, isn't leader",
+			kubectlOut: `{"holderIdentity":"some-other-instance_some-uuid","leaseDurationSeconds":15,"acquireTime":"2020-07-13T20:16:19Z","renewTime":"2020-07-16T16:48:51Z","leaderTransitions":0}`,
+			expected:   false,
+		},
+		{
+			desc:       "holderIdentity empty",
+			kubectlOut: `{"holderIdentity":"","leaseDurationSeconds":15,"acquireTime":"2020-07-13T20:16:19Z","renewTime":"2020-07-16T16:48:51Z","leaderTransitions":0}`,
+			expected:   true,
+		},
+		{
+			desc:       "no holderIdentity",
+			kubectlOut: `{"leaseDurationSeconds":15,"acquireTime":"2020-07-13T20:16:19Z","renewTime":"2020-07-16T16:48:51Z","leaderTransitions":0}`,
+			expected:   true,
+		},
+		{
+			desc:       "empty output",
+			kubectlOut: "",
+			expected:   true,
+		},
+		{
+			desc:          "kubectl error",
+			kubectlErrOut: "not found",
+			kubectlErr:    errors.New("exit code: 1"),
+			expected:      true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			am := &addonManager{
+				hostname:    testHostname,
+				kubectlOpts: testKubectlOpts,
+				kubectl: func(stdout, stderr io.Writer, args ...string) error {
+					if !reflect.DeepEqual(expectedKubectlArgs, args) {
+						t.Errorf("incorrect args passed to kubectl. Wanted: %#v, Got: %#v", expectedKubectlArgs, args)
+					}
+					if tc.kubectlOut != "" {
+						io.WriteString(stdout, tc.kubectlOut)
+					}
+					if tc.kubectlErrOut != "" {
+						io.WriteString(stderr, tc.kubectlErrOut)
+					}
+					return tc.kubectlErr
+				},
+			}
+			result := am.isLeader()
+			if tc.expected != result {
+				t.Errorf("isLeader() returned %v, wanted %v", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestAddonManager(t *testing.T) {
+	tcs := []struct {
+		desc string
+		env  map[string]string
+
+		expected *addonManager
+	}{
+		{
+			desc: "default",
+			env:  map[string]string{},
+
+			expected: &addonManager{
+				addonPath:            "/etc/kubernetes/addons",
+				admissionControlsDir: "/etc/kubernetes/admission-controls",
+				checkInterval:        60 * time.Second,
+				kubectlPath:          "/usr/bin/kubectl",
+				leaderElection:       true,
+				pruneWhitelistFlags: []string{
+					"--prune-whitelist", "core/v1/ConfigMap",
+					"--prune-whitelist", "core/v1/Endpoints",
+					"--prune-whitelist", "core/v1/Namespace",
+					"--prune-whitelist", "core/v1/PersistentVolumeClaim",
+					"--prune-whitelist", "core/v1/PersistentVolume",
+					"--prune-whitelist", "core/v1/Pod",
+					"--prune-whitelist", "core/v1/ReplicationController",
+					"--prune-whitelist", "core/v1/Secret",
+					"--prune-whitelist", "core/v1/Service",
+					"--prune-whitelist", "batch/v1/Job",
+					"--prune-whitelist", "batch/v1beta1/CronJob",
+					"--prune-whitelist", "apps/v1/DaemonSet",
+					"--prune-whitelist", "apps/v1/Deployment",
+					"--prune-whitelist", "apps/v1/ReplicaSet",
+					"--prune-whitelist", "apps/v1/StatefulSet",
+					"--prune-whitelist", "extensions/v1beta1/Ingress",
+				},
+			},
+		},
+		{
+			desc: "all env vars set",
+			env: map[string]string{
+				"HOSTNAME":                         "testHostname",
+				"KUBECTL_OPTS":                     "--kubeconfig=/some/dir/kubeconfig.json",
+				"ADDON_PATH":                       "/test/addon/dir",
+				"KUBECTL_BIN":                      "/usr/bin/testKubectl",
+				"ADDON_MANAGER_LEADER_ELECTION":    "false",
+				"KUBECTL_PRUNE_WHITELIST_OVERRIDE": "core/v1/OverrideResource extensions/v1beta1/OverrideResource",
+				"KUBECTL_EXTRA_PRUNE_WHITELIST":    "core/v1/ExtraResource extensions/v1beta1/ExtraResource",
+				"TEST_ADDON_CHECK_INTERVAL_SEC":    "42",
+			},
+
+			expected: &addonManager{
+				addonPath:            "/test/addon/dir",
+				admissionControlsDir: "/etc/kubernetes/admission-controls",
+				checkInterval:        42 * time.Second,
+				hostname:             "testHostname",
+				kubectlOpts:          "--kubeconfig=/some/dir/kubeconfig.json",
+				kubectlPath:          "/usr/bin/testKubectl",
+				leaderElection:       false,
+				pruneWhitelistFlags: []string{
+					"--prune-whitelist", "core/v1/OverrideResource",
+					"--prune-whitelist", "extensions/v1beta1/OverrideResource",
+					"--prune-whitelist", "core/v1/ExtraResource",
+					"--prune-whitelist", "extensions/v1beta1/ExtraResource",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			am, err := AddonManager(func(key string) string {
+				return tc.env[key]
+			})
+			if err != nil {
+				t.Fatalf("AddonManager() returned error: %v", err)
+			}
+			if am.kubectl == nil {
+				t.Error("AddonManager() returned an addon manager without `kubectl` implementation.")
+			}
+			am.kubectl = nil // set function var to nil so that DeepEqual can work
+			if !reflect.DeepEqual(tc.expected, am) {
+				t.Errorf("AddonManager() returned %#v, wanted %#v", tc.expected, am)
+			}
+		})
+	}
+}
+
+func TestMakePruneWhitelistFlags(t *testing.T) {
+	tcs := []struct {
+		desc                   string
+		pruneWhitelistOverride string
+		extraPruneWhitelist    string
+
+		expected []string
+	}{
+		{
+			desc: "default",
+
+			expected: []string{
+				"--prune-whitelist", "core/v1/ConfigMap",
+				"--prune-whitelist", "core/v1/Endpoints",
+				"--prune-whitelist", "core/v1/Namespace",
+				"--prune-whitelist", "core/v1/PersistentVolumeClaim",
+				"--prune-whitelist", "core/v1/PersistentVolume",
+				"--prune-whitelist", "core/v1/Pod",
+				"--prune-whitelist", "core/v1/ReplicationController",
+				"--prune-whitelist", "core/v1/Secret",
+				"--prune-whitelist", "core/v1/Service",
+				"--prune-whitelist", "batch/v1/Job",
+				"--prune-whitelist", "batch/v1beta1/CronJob",
+				"--prune-whitelist", "apps/v1/DaemonSet",
+				"--prune-whitelist", "apps/v1/Deployment",
+				"--prune-whitelist", "apps/v1/ReplicaSet",
+				"--prune-whitelist", "apps/v1/StatefulSet",
+				"--prune-whitelist", "extensions/v1beta1/Ingress",
+			},
+		},
+		{
+			desc:                   "override set",
+			pruneWhitelistOverride: "core/v1/OverrideResource extensions/v1beta1/OverrideResource",
+
+			expected: []string{
+				"--prune-whitelist", "core/v1/OverrideResource",
+				"--prune-whitelist", "extensions/v1beta1/OverrideResource",
+			},
+		},
+		{
+			desc:                "extra set",
+			extraPruneWhitelist: "core/v1/ExtraResource extensions/v1beta1/ExtraResource",
+
+			expected: []string{
+				"--prune-whitelist", "core/v1/ConfigMap",
+				"--prune-whitelist", "core/v1/Endpoints",
+				"--prune-whitelist", "core/v1/Namespace",
+				"--prune-whitelist", "core/v1/PersistentVolumeClaim",
+				"--prune-whitelist", "core/v1/PersistentVolume",
+				"--prune-whitelist", "core/v1/Pod",
+				"--prune-whitelist", "core/v1/ReplicationController",
+				"--prune-whitelist", "core/v1/Secret",
+				"--prune-whitelist", "core/v1/Service",
+				"--prune-whitelist", "batch/v1/Job",
+				"--prune-whitelist", "batch/v1beta1/CronJob",
+				"--prune-whitelist", "apps/v1/DaemonSet",
+				"--prune-whitelist", "apps/v1/Deployment",
+				"--prune-whitelist", "apps/v1/ReplicaSet",
+				"--prune-whitelist", "apps/v1/StatefulSet",
+				"--prune-whitelist", "extensions/v1beta1/Ingress",
+				"--prune-whitelist", "core/v1/ExtraResource",
+				"--prune-whitelist", "extensions/v1beta1/ExtraResource",
+			},
+		},
+		{
+			desc:                   "override and extra set",
+			pruneWhitelistOverride: "core/v1/OverrideResource extensions/v1beta1/OverrideResource",
+			extraPruneWhitelist:    "core/v1/ExtraResource extensions/v1beta1/ExtraResource",
+
+			expected: []string{
+				"--prune-whitelist", "core/v1/OverrideResource",
+				"--prune-whitelist", "extensions/v1beta1/OverrideResource",
+				"--prune-whitelist", "core/v1/ExtraResource",
+				"--prune-whitelist", "extensions/v1beta1/ExtraResource",
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			flags := makePruneWhitelistFlags(func(key string) string {
+				if key == "KUBECTL_PRUNE_WHITELIST_OVERRIDE" {
+					return tc.pruneWhitelistOverride
+				}
+				if key == "KUBECTL_EXTRA_PRUNE_WHITELIST" {
+					return tc.extraPruneWhitelist
+				}
+				t.Errorf("unknown ENV value requested: %q", key)
+				return ""
+			})
+			if !reflect.DeepEqual(tc.expected, flags) {
+				t.Errorf("makePruneWhitelistFlags() returned %v, wanted %v", flags, tc.expected)
+			}
+		})
+	}
+}
+
+func TestWaitForSystemServiceAccount(t *testing.T) {
+	t.Parallel()
+	testHostname := "test-instance"
+	testKubectlOpts := "--kubeconfig=/some/dir/kubeconfig.json"
+	expectedKubectlArgs := []string{testKubectlOpts, "get", "-n", "kube-system", "serviceaccount", "default", "-o", "go-template={{with index .secrets 0}}{{.name}}{{end}}"}
+	tcs := []struct {
+		desc        string
+		kubectlOuts []string
+		kubectlErrs []error
+
+		expectedAttempts int
+	}{
+		{
+			desc:             "happy case",
+			kubectlOuts:      []string{"service-account-t0ken"},
+			expectedAttempts: 1,
+		},
+		{
+			desc:             "wait for token",
+			kubectlOuts:      []string{"", "", "service-account-t0ken"},
+			expectedAttempts: 3,
+		},
+		{
+			desc:             "retry on error",
+			kubectlOuts:      []string{"", "service-account-t0ken"},
+			kubectlErrs:      []error{errors.New("exit status: 1")},
+			expectedAttempts: 2,
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			numAttempts := 0
+			am := &addonManager{
+				hostname:    testHostname,
+				kubectlOpts: testKubectlOpts,
+				kubectl: func(stdout, stderr io.Writer, args ...string) error {
+					numAttempts++
+					if !reflect.DeepEqual(expectedKubectlArgs, args) {
+						t.Errorf("incorrect args passed to kubectl. Wanted: %#v, Got: %#v", expectedKubectlArgs, args)
+					}
+					if len(tc.kubectlOuts) > 0 {
+						io.WriteString(stdout, tc.kubectlOuts[0])
+						tc.kubectlOuts = tc.kubectlOuts[1:]
+					}
+					if len(tc.kubectlErrs) > 0 {
+						err := tc.kubectlErrs[0]
+						tc.kubectlErrs = tc.kubectlErrs[1:]
+						return err
+					}
+					return nil
+				},
+			}
+			am.waitForSystemServiceAccount()
+			if tc.expectedAttempts != numAttempts {
+				t.Errorf("waitForSystemServiceAccount() made %d attempts to wait for the kube-system service account, expected %d", numAttempts, tc.expectedAttempts)
+			}
+		})
+	}
+}
+
+func TestReconcileAddons(t *testing.T) {
+	testKubectlOpts := "--kubeconfig=/some/dir/kubeconfig.json"
+	testAddonPath := "/test/addon/dir"
+	testPruneWhitelistFlags := []string{"--prune-whitelist", "core/v1/ReconcileAddonsTestResource"}
+	expectedDeprecatedLabelKubectlArgs := []string{
+		testKubectlOpts,
+		"apply", "-f", testAddonPath, "--recursive",
+		"-l", "kubernetes.io/cluster-service=true,addonmanager.kubernetes.io/mode!=EnsureExists",
+		"--prune=true", "--prune-whitelist", "core/v1/ReconcileAddonsTestResource"}
+	expectedKubectlArgs := []string{
+		testKubectlOpts,
+		"apply", "-f", testAddonPath, "--recursive",
+		"-l", "kubernetes.io/cluster-service!=true,addonmanager.kubernetes.io/mode=Reconcile",
+		"--prune=true", "--prune-whitelist", "core/v1/ReconcileAddonsTestResource"}
+
+	var calledWithDeprecatedLabel, calledWithAddonManagerLabel bool
+
+	am := &addonManager{
+		addonPath:           testAddonPath,
+		kubectlOpts:         testKubectlOpts,
+		pruneWhitelistFlags: testPruneWhitelistFlags,
+		kubectl: func(_, _ io.Writer, args ...string) error {
+			if reflect.DeepEqual(expectedDeprecatedLabelKubectlArgs, args) {
+				calledWithDeprecatedLabel = true
+				return nil
+			}
+			if reflect.DeepEqual(expectedKubectlArgs, args) {
+				calledWithAddonManagerLabel = true
+				return nil
+			}
+
+			t.Errorf("kubectl called with unexpected args: %#v", args)
+			return errors.New("called expectedly")
+		},
+	}
+
+	am.reconcileAddons()
+
+	if !calledWithDeprecatedLabel {
+		t.Error("expected `kubectl apply` to be called with deprecated label, was not")
+	}
+	if !calledWithAddonManagerLabel {
+		t.Error("expected `kubectl apply` to be called with addon-manager label, was not")
+	}
+}
+
+func TestEnsureAddons(t *testing.T) {
+	testKubectlOpts := "--kubeconfig=/some/dir/kubeconfig.json"
+	testAddonPath := "/test/addon/dir"
+	testPruneWhitelistFlags := []string{"--prune-whitelist", "core/v1/ReconcileAddonsTestResource"}
+	expectedKubectlArgs := []string{
+		testKubectlOpts,
+		"create", "-f", "/test/addon/dir", "--recursive",
+		"-l", "addonmanager.kubernetes.io/mode=EnsureExists"}
+
+	var called bool
+
+	am := &addonManager{
+		addonPath:           testAddonPath,
+		kubectlOpts:         testKubectlOpts,
+		pruneWhitelistFlags: testPruneWhitelistFlags,
+		kubectl: func(_, _ io.Writer, args ...string) error {
+			if reflect.DeepEqual(expectedKubectlArgs, args) {
+				called = true
+				return nil
+			}
+
+			t.Errorf("kubectl called with unexpected args: %#v", args)
+			return errors.New("called expectedly")
+		},
+	}
+
+	am.ensureAddons()
+
+	if !called {
+		t.Error("expected `kubectl create` to be called with expected args, was not")
+	}
+}
+
+func TestExtractHolderIdentity(t *testing.T) {
+	tcs := []struct {
+		desc  string
+		input string
+
+		expected string
+	}{
+		{
+			desc:     "happy case",
+			input:    `{"holderIdentity":"test-instance","leaseDurationSeconds":15,"acquireTime":"2020-07-13T20:16:19Z","renewTime":"2020-07-16T16:48:51Z","leaderTransitions":0}`,
+			expected: "test-instance",
+		},
+		{
+			desc:     "holderIdentity empty",
+			input:    `{"holderIdentity":"","leaseDurationSeconds":15,"acquireTime":"2020-07-13T20:16:19Z","renewTime":"2020-07-16T16:48:51Z","leaderTransitions":0}`,
+			expected: "",
+		},
+		{
+			desc:     "no holderIdentity",
+			input:    `{"leaseDurationSeconds":15,"acquireTime":"2020-07-13T20:16:19Z","renewTime":"2020-07-16T16:48:51Z","leaderTransitions":0}`,
+			expected: "",
+		},
+		{
+			desc:     "empty input",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			result := extractHolderIdentity(tc.input)
+			if tc.expected != result {
+				t.Errorf("extractHolderIdentity(%q) returned %q, wanted %q", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestEnsureDefaultAdmissionControlsObjects(t *testing.T) {
+	testKubectlOpts := "--kubeconfig=/some/dir/kubeconfig.json"
+
+	tcs := []struct {
+		desc           string
+		testFiles      []string
+		extraTestFiles []string
+	}{
+		{
+			desc:      "json",
+			testFiles: []string{"test_file.json"},
+		},
+		{
+			desc:      "yaml",
+			testFiles: []string{"test_file.yaml"},
+		},
+		{
+			desc:           "mixed",
+			testFiles:      []string{"test_file.yaml", "test_file.json"},
+			extraTestFiles: []string{"should_be_ignored.txt"},
+		},
+		{
+			desc:           "nested dir",
+			testFiles:      []string{"test_file.yaml", "nested/test_file.json"},
+			extraTestFiles: []string{"should_be_ignored.txt"},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			testDir, err := ioutil.TempDir("", "test_admissions_controls_dir_*")
+			if err != nil {
+				t.Fatalf("error creating test directory: %v", err)
+			}
+			defer os.RemoveAll(testDir)
+
+			for _, testFile := range tc.testFiles {
+				path := filepath.Join(testDir, testFile)
+				os.MkdirAll(filepath.Dir(path), os.ModePerm)
+				if err := ioutil.WriteFile(path, []byte("test file contents"), 0666); err != nil {
+					t.Fatalf("error creating test file %s: %v", path, err)
+				}
+			}
+			for _, extraFile := range tc.extraTestFiles {
+				path := filepath.Join(testDir, extraFile)
+				os.MkdirAll(filepath.Dir(path), os.ModePerm)
+				if err := ioutil.WriteFile(path, []byte("extra test file contents"), 0666); err != nil {
+					t.Fatalf("error creating extra test file %s: %v", path, err)
+				}
+			}
+
+			kubectlArgs := [][]string{}
+			am := &addonManager{
+				admissionControlsDir: testDir,
+				kubectlOpts:          testKubectlOpts,
+				kubectl: func(_, _ io.Writer, args ...string) error {
+					kubectlArgs = append(kubectlArgs, args)
+					return nil
+				},
+			}
+
+			am.ensureDefaultAdmissionControlsObjects()
+
+			for _, testFile := range tc.testFiles {
+				expectedArgs := []string{testKubectlOpts, "--namespace=default", "apply", "-f", filepath.Join(testDir, testFile)}
+				call := -1
+				for i, args := range kubectlArgs {
+					if reflect.DeepEqual(args, expectedArgs) {
+						call = i
+						break
+					}
+				}
+				if call == -1 {
+					t.Errorf("expected `kubectl` to be called with args %q", expectedArgs)
+					continue
+				}
+				kubectlArgs = append(kubectlArgs[:call], kubectlArgs[call+1:]...)
+			}
+			for _, args := range kubectlArgs {
+				t.Errorf("`kubectl` unexpectedly called with args %q", args)
+			}
+		})
+	}
+
+}

--- a/bootstrap/go.mod
+++ b/bootstrap/go.mod
@@ -1,0 +1,5 @@
+module sigs.k8s.io/cluster-addons/bootstrap
+
+go 1.15
+
+require k8s.io/klog/v2 v2.3.0

--- a/bootstrap/go.sum
+++ b/bootstrap/go.sum
@@ -1,0 +1,5 @@
+github.com/go-logr/logr v0.2.0 h1:QvGt2nLcHH0WK9orKa+ppBPAxREcH364nPUedEpK0TY=
+github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
+k8s.io/klog/v2 v2.3.0 h1:WmkrnW7fdrm0/DMClc+HIxtftvxVIPAhlVwMQo5yLco=
+k8s.io/klog/v2 v2.3.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -1,0 +1,48 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// The cluster-addons-bootstrap ensures that a given set of addon Objects is installed in the cluster.
+package main
+
+import (
+	"flag"
+	"math/rand"
+	"os"
+	"time"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/cluster-addons/bootstrap/app"
+)
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+
+	klog.InitFlags(nil)
+	flag.Set("alsologtostderr", "false") // false is default, but this is informative
+
+	flag.Parse()
+	// make sure we flush before exiting
+	defer klog.Flush()
+
+	am, err := app.AddonManager(os.Getenv)
+
+	if err != nil {
+		klog.Exit(err)
+	}
+
+	if err := am.Run(); err != nil {
+		klog.Exit(err)
+	}
+}

--- a/hack/unit-test.sh
+++ b/hack/unit-test.sh
@@ -31,3 +31,6 @@ make test -C dashboard
 
 echo "****** Testing Metrics-server Operator ******"
 make test -C metrics-server
+
+echo "****** Testing Bootstrap Utility ******"
+make test -C bootstrap


### PR DESCRIPTION
This is a re-homing of https://github.com/kubernetes/kubernetes/pull/92978

The course of action agreed upon during the [sig-arch meeting](https://docs.google.com/document/d/1BlmHq5uPyBUDlppYqAAzslVbAO8hilgjqZUTaNXUhKM/edit#bookmark=kix.mcg6toz81hza) was that addon-manager would be adopted by cluster-addons and used as a bootstrap mechanism.

I implemented this as a drop-in replacement for [k/k's `addon-manager`](https://github.com/kubernetes/kubernetes/tree/99dd7570eb59a4ff040a7656c9d2b879f47acc59/cluster/addons/addon-manager), but we can improve things over time. For example, we may want to use the k8s client directly and/or use watches to improve performance. The immediate benefits are:
* unit tests
* elimination of dependencies on `bash` et al. and migration to a `distroless` image base

TODOs:
* port the bugfix from https://github.com/kubernetes/kubernetes/pull/93762
* implement a dedicated leader election for the cluster-addons bootstrapper