### PR TITLE
Fix coredns & dashboard operators for nonroot

### DIFF
--- a/coredns/Dockerfile
+++ b/coredns/Dockerfile
@@ -23,13 +23,17 @@ COPY controllers/ controllers/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
+# Copy the channels so we can chmod them before we go distroless
+COPY channels/ /channels/
+RUN chmod -R a=rX /channels/
+
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /go/src/coredns/manager .
 COPY --from=kubectl /usr/bin/kubectl /usr/bin/kubectl
-COPY channels/ channels/
+COPY --from=builder /channels/ channels/
 USER nonroot:nonroot
 
 ENTRYPOINT ["/manager"]

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -23,12 +23,16 @@ COPY controllers/ controllers/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
+# Copy the channels so we can chmod them before we go distroless
+COPY channels/ /channels/
+RUN chmod -R a=rX /channels/
+
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=kubectl /usr/bin/kubectl /usr/bin/kubectl
-COPY channels/ channels/
+COPY --from=builder /channels/ channels/
 USER nonroot:nonroot
 ENTRYPOINT ["./manager"]


### PR DESCRIPTION
They are not able to load from the channels/ directory when running as nonroot.