### PR TITLE
Update README in kubeproxy-operator

### DIFF
--- a/kubeproxy/README.md
+++ b/kubeproxy/README.md
@@ -48,7 +48,11 @@ kubeproxy-operator is a Kubernetes operator for managing kubeproxy.
    ```bash
    make docker-build
 
-   make deploy
+   docker image save controller:latest > controller-latest.tar
+   kinder cp ./controller-latest.tar @cp1:/kind/
+   kinder exec @cp1 -- ctr -n k8s.io image import /kind/controller-latest.tar
+   
+   IMG=docker.io/library/controller:latest make deploy
    ```
 
 4. Install CRD
@@ -62,6 +66,6 @@ kubeproxy-operator is a Kubernetes operator for managing kubeproxy.
 
    ```bash
    kubectl get kubeproxy -n kube-system
-   kubectl get daemonset -n kube-system kubeproxy
+   kubectl get daemonset -n kube-system kube-proxy
    kubectl get nodes
    ```


### PR DESCRIPTION
This PR updates README.md in kubeproxy-operator.

In step 3 on "Running in a cluster" section, it is needed that `kind-controll-plane-1` loads controller container image created by `make docker-build`.
Container name on `kind-controll-plane-1` is `docker.io/library/controller`, that's why set `IMG=docker.io/library/controller:latest` on run `make deploy`.  