### PR TITLE
rbac-generator improvements

### DIFF
--- a/tools/rbac-gen/pkg/convert/convert.go
+++ b/tools/rbac-gen/pkg/convert/convert.go
@@ -1,15 +1,15 @@
 package convert
 
 import (
-	"bytes"
 	"context"
+	"fmt"
 	"strings"
 
 	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
-	"sigs.k8s.io/yaml"
 )
 
 type BuildRoleOptions struct {
@@ -17,29 +17,51 @@ type BuildRoleOptions struct {
 	Namespace          string
 	ServiceAccountName string
 	Supervisory        bool
+
+	// CRD is the name of the CRD to generate permissions for.
+	CRD string
+
+	// LimitResourceNames specifies that RBAC permissions should restrict to resource names in the manifest.
+	LimitResourceNames bool
+
+	// LimitNamespaces specifies that RBAC permissions should restrict to resource names in the manifest.
+	LimitNamespaces bool
+
+	// Format specifies the format we should write in (yaml or kubebuilder)
+	Format string
 }
 
-func ParseYAMLtoRole(manifestStr string, opt BuildRoleOptions) (string, error) {
-	ctx := context.Background()
+// BuildRole parses the manifest and generates Role/ClusterRole objects for manipulating them.
+func BuildRole(ctx context.Context, manifestStr string, opt BuildRoleOptions) ([]runtime.Object, error) {
+	var objects []runtime.Object
+
 	objs, err := manifest.ParseObjects(ctx, manifestStr)
 	if err != nil {
-		return "", err
+		return nil, err
+	}
+	if len(objs.Blobs) != 0 {
+		return nil, fmt.Errorf("unable to parse manifest fully")
 	}
 
-	clusterRole := v1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      opt.Name,
-			Namespace: opt.Namespace,
-		},
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ClusterRole",
-			APIVersion: "rbac.authorization.k8s.io/v1",
-		},
-	}
+	// Build rules, keyed by namespace.  "" is used for cluster-scoped rules.
+	ruleMap := make(map[string]*ruleSet)
+	ruleMap[""] = &ruleSet{}
+
 	// to deal with duplicates, we keep a map of all the kinds that has been added so far
 	kindMap := make(map[string]bool)
 
 	for _, obj := range objs.Items {
+		ruleSetKey := ""
+		if opt.LimitNamespaces {
+			ruleSetKey = obj.Namespace
+		}
+
+		rules := ruleMap[ruleSetKey]
+		if rules == nil {
+			rules = &ruleSet{}
+			ruleMap[ruleSetKey] = rules
+		}
+
 		// The generated role needs the rules from any role or clusterrole
 		if obj.Kind == "Role" || obj.Kind == "ClusterRole" {
 			if opt.Supervisory {
@@ -51,61 +73,155 @@ func ParseYAMLtoRole(manifestStr string, opt BuildRoleOptions) (string, error) {
 			// Converting from unstructured to v1.ClusterRole
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstruct.Object, &newClusterRole)
 			if err != nil {
-				return "", err
+				return nil, err
 			}
-			clusterRole.Rules = append(clusterRole.Rules, newClusterRole.Rules...)
+			rules.Add(newClusterRole.Rules...)
 		}
 
-		if !kindMap[obj.Group+"::"+obj.Kind] {
+		// needs plural of kind
+		resource := ResourceFromKind(obj.Kind)
+
+		if opt.LimitResourceNames {
+			rules.Add(v1.PolicyRule{
+				APIGroups:     []string{obj.Group},
+				Resources:     []string{resource},
+				ResourceNames: []string{obj.Name},
+				Verbs:         []string{"update", "delete", "patch"},
+			})
+
+			rules.Add(v1.PolicyRule{
+				APIGroups: []string{obj.Group},
+				Resources: []string{resource},
+				Verbs:     []string{"create"},
+			})
+
+			rules.Add(v1.PolicyRule{
+				APIGroups: []string{obj.Group},
+				Resources: []string{resource},
+				Verbs:     []string{"get", "list", "watch"},
+			})
+
+		} else if !kindMap[obj.Group+"::"+obj.Kind] {
 			newRule := v1.PolicyRule{
 				APIGroups: []string{obj.Group},
-				// needs plural of kind
-				Resources: []string{ResourceFromKind(obj.Kind)},
+				Resources: []string{resource},
 				Verbs:     []string{"create", "update", "delete", "get"},
 			}
-			clusterRole.Rules = append(clusterRole.Rules, newRule)
+			rules.Add(newRule)
 			kindMap[obj.Group+"::"+obj.Kind] = true
 		}
 	}
 
-	output, err := yaml.Marshal(&clusterRole)
-	buf := bytes.NewBuffer(output)
+	if opt.CRD != "" {
+		crdGroupResource := schema.ParseGroupResource(opt.CRD)
 
-	// if saName is passed in, generate YAML for rolebinding
-	if opt.ServiceAccountName != "" {
-		clusterRoleBinding := v1.ClusterRoleBinding{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "ClusterRoleBinding",
-				APIVersion: "rbac.authorization.k8s.io/v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: opt.Namespace,
-				Name:      opt.Name + "-binding",
-			},
-			Subjects: []v1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					Name:      opt.ServiceAccountName,
-					Namespace: opt.Namespace,
-				},
-			},
-			RoleRef: v1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "ClusterRole",
-				Name:     opt.Name,
-			},
-		}
+		// TODO: Should we assume namespace scoped?
+		rules := ruleMap[""]
 
-		outputBinding, err := yaml.Marshal(&clusterRoleBinding)
-		if err != nil {
-			return "", err
-		}
-		buf.WriteString("\n---\n\n")
-		buf.Write(outputBinding)
+		rules.Add(v1.PolicyRule{
+			APIGroups: []string{crdGroupResource.Group},
+			Resources: []string{crdGroupResource.Resource},
+			Verbs:     []string{"get", "list", "patch", "update", "watch"},
+		})
+		rules.Add(v1.PolicyRule{
+			APIGroups: []string{crdGroupResource.Group},
+			Resources: []string{crdGroupResource.Resource + "/status"},
+			Verbs:     []string{"get", "patch", "update"},
+		})
 	}
-	return buf.String(), err
+
+	// Normalize and wrap the rules in Role or ClusterRole objects
+	for ns, rules := range ruleMap {
+		rules.normalize()
+
+		if ns != "" {
+			role := &v1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      opt.Name,
+					Namespace: ns,
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Role",
+					APIVersion: "rbac.authorization.k8s.io/v1",
+				},
+				Rules: rules.rules,
+			}
+			objects = append(objects, role)
+
+			// if saName is passed in, generate YAML for rolebinding
+			if opt.ServiceAccountName != "" {
+				roleBinding := v1.RoleBinding{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "RoleBinding",
+						APIVersion: "rbac.authorization.k8s.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      opt.Name + "-binding",
+						Namespace: ns,
+					},
+					Subjects: []v1.Subject{
+						{
+							Kind:      "ServiceAccount",
+							Name:      opt.ServiceAccountName,
+							Namespace: opt.Namespace,
+						},
+					},
+					RoleRef: v1.RoleRef{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "Role",
+						Name:     opt.Name,
+					},
+				}
+
+				objects = append(objects, &roleBinding)
+			}
+		} else {
+			role := &v1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: opt.Name,
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ClusterRole",
+					APIVersion: "rbac.authorization.k8s.io/v1",
+				},
+				Rules: rules.rules,
+			}
+			objects = append(objects, role)
+
+			// if saName is passed in, generate YAML for rolebinding
+			if opt.ServiceAccountName != "" {
+				roleBinding := v1.ClusterRoleBinding{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ClusterRoleBinding",
+						APIVersion: "rbac.authorization.k8s.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: opt.Name + "-binding",
+					},
+					Subjects: []v1.Subject{
+						{
+							Kind:      "ServiceAccount",
+							Name:      opt.ServiceAccountName,
+							Namespace: opt.Namespace,
+						},
+					},
+					RoleRef: v1.RoleRef{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "ClusterRole",
+						Name:     opt.Name,
+					},
+				}
+
+				objects = append(objects, &roleBinding)
+			}
+		}
+	}
+
+	return objects, err
 }
 
+// ResourceFromKind returns the resource name for the given kind.
+// Because we don't require a cluster, it assumes the kind -> resource mapping follows normal conventions.
 func ResourceFromKind(kind string) string {
 	if string(kind[len(kind)-1]) == "s" {
 		return strings.ToLower(kind) + "es"

--- a/tools/rbac-gen/pkg/convert/convert_test.go
+++ b/tools/rbac-gen/pkg/convert/convert_test.go
@@ -1,13 +1,15 @@
 package convert
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"golang.org/x/xerrors"
 
 	"k8s.io/apimachinery/pkg/util/diff"
 )
@@ -41,102 +43,101 @@ func TestRBACGen(t *testing.T) {
 			continue
 		}
 
-		b, err := ioutil.ReadFile(p)
-		if err != nil {
-			t.Errorf("error reading file %s: %v", p, err)
-			continue
-		}
+		t.Run(f.Name(), func(t *testing.T) {
+			ctx := context.Background()
 
-		opt := BuildRoleOptions{
-			Name:      "generated-role",
-			Namespace: "kube-system",
-		}
-		actualYAML, err := ParseYAMLtoRole(string(b), opt)
-		if err != nil {
-			t.Errorf("error parsing YAML %s: %v", p, err)
-			continue
-		}
-
-		expectedPath := strings.Replace(p, "in.yaml", "out.yaml", -1)
-		var expectedYAML string
-
-		{
-			b, err := ioutil.ReadFile(expectedPath)
+			b, err := ioutil.ReadFile(p)
 			if err != nil {
-				t.Errorf("error reading file %s: %v", expectedPath, err)
-				continue
-			}
-			expectedYAML = string(b)
-		}
-
-		if expectedYAML != actualYAML {
-			if err := diffFiles(t, expectedPath, actualYAML); err != nil {
-				t.Logf("failed to run system diff, falling back to string diff: %v", err)
-				t.Logf("diff: %s", diff.StringDiff(actualYAML, expectedYAML))
+				t.Fatalf("error reading file %s: %v", p, err)
 			}
 
-			t.Errorf("unexpected diff between actual and expected YAML. See previous output for details.")
-			// TODO: Do we want to replace the out.yaml if HACK_AUTOFIX_EXPECTED_OUTPUT="true" is set?
-			// t.Logf(`To regenerate the output based on this result,
-			// rerun this test with HACK_AUTOFIX_EXPECTED_OUTPUT="true"`)
-		}
+			opt := BuildRoleOptions{
+				Name:      "generated-role",
+				Namespace: "kube-system",
+			}
+			actualObjects, err := BuildRole(ctx, string(b), opt)
+			if err != nil {
+				t.Fatalf("error building role %s: %v", p, err)
+			}
+
+			actualYAML, err := ToYAML(actualObjects)
+			if err != nil {
+				t.Fatalf("error converting to YAML %s: %v", p, err)
+			}
+
+			expectedPath := strings.Replace(p, "in.yaml", "out.yaml", -1)
+
+			CheckGoldenFile(t, expectedPath, string(actualYAML))
+		})
 	}
 }
 
-// Had to copy out this func from kubebuider-declarative-pattern. Could we simply export it?
-func diffFiles(t *testing.T, expectedPath, actual string) error {
+func CheckGoldenFile(t *testing.T, expectedPath, actual string) {
 	t.Helper()
-	writeTmp := func(content string) (string, error) {
-		tmp, err := ioutil.TempFile("", "*.yaml")
+
+	var expected string
+	{
+		b, err := ioutil.ReadFile(expectedPath)
 		if err != nil {
-			return "", err
+			t.Fatalf("error reading file %s: %v", expectedPath, err)
 		}
-		defer func() {
-			tmp.Close()
-		}()
-		if _, err := tmp.Write([]byte(content)); err != nil {
-			return "", err
-		}
-		return tmp.Name(), nil
+		expected = string(b)
 	}
 
-	actualTmp, err := writeTmp(actual)
+	delta, err := runDiffCommand(actual, expected)
 	if err != nil {
-		return xerrors.Errorf("write actual yaml to temp file failed: %w", err)
+		t.Logf("failed to run system diff, falling back to string diff: %v", err)
+		delta = diff.StringDiff(actual, expected)
 	}
-	t.Logf("Wrote actual to %s", actualTmp)
+
+	if delta == "" {
+		return
+	}
+
+	t.Errorf("Diff: expected - + actual\n%s", delta)
+	t.Errorf("unexpected diff between actual and expected YAML. See previous output for details.")
+
+	if os.Getenv("HACK_AUTOFIX_EXPECTED_OUTPUT") != "" {
+		if err := os.WriteFile(expectedPath, []byte(actual), 0644); err != nil {
+			t.Errorf("failed to write expected file %q: %w", expectedPath, err)
+		}
+	} else {
+		t.Logf(`To regenerate the output based on this result, rerun this test with HACK_AUTOFIX_EXPECTED_OUTPUT=1`)
+	}
+}
+
+func runDiffCommand(actual, expected string) (string, error) {
+	tempDir, err := os.MkdirTemp("", "")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp dir: %w", err)
+	}
+
+	defer os.RemoveAll(tempDir)
+
+	actualPath := filepath.Join(tempDir, "actual.yaml")
+	if err := ioutil.WriteFile(actualPath, []byte(actual), 0644); err != nil {
+		return "", fmt.Errorf("failed to write file %q: %w", actualPath, err)
+	}
+
+	expectedPath := filepath.Join(tempDir, "expected.yaml")
+	if err := ioutil.WriteFile(expectedPath, []byte(expected), 0644); err != nil {
+		return "", fmt.Errorf("failed to write file %q: %w", expectedPath, err)
+	}
 
 	// pls to use unified diffs, kthxbai?
-	cmd := exec.Command("diff", "-u", expectedPath, actualTmp)
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return xerrors.Errorf("set up stdout pipe from diff failed: %w", err)
-	}
+	cmd := exec.Command("diff", "-u", expectedPath, actualPath)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
 
-	if err := cmd.Start(); err != nil {
-		return xerrors.Errorf("start command failed: %w", err)
-	}
-
-	diff, err := ioutil.ReadAll(stdout)
-	if err != nil {
-		return xerrors.Errorf("read from diff stdout failed: %w", err)
-	}
-
-	if err := cmd.Wait(); err != nil {
-		exitErr, ok := err.(*exec.ExitError)
-		if !ok {
-			return xerrors.Errorf("wait for command to finish failed: %w", err)
+	if err := cmd.Run(); err != nil {
+		// exit code 1 means there was a diff
+		if cmd.ProcessState.ExitCode() == 1 {
+			return stdout.String(), nil
 		}
-		t.Logf("Diff exited %s", exitErr)
+
+		return "", fmt.Errorf("failed to run diff: %w", err)
 	}
 
-	expectedAbs, err := filepath.Abs(expectedPath)
-	if err != nil {
-		t.Logf("getting absolute path for %s failed: %s", expectedPath, err)
-		expectedAbs = expectedPath
-	}
-
-	t.Logf("View diff: meld %s %s", expectedAbs, actualTmp)
-	t.Logf("Diff: expected - + actual\n%s", diff)
-	return nil
+	return stdout.String(), nil
 }

--- a/tools/rbac-gen/pkg/convert/kubebuilder.go
+++ b/tools/rbac-gen/pkg/convert/kubebuilder.go
@@ -1,0 +1,72 @@
+package convert
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	v1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+)
+
+// KubebuilderConverter converts Role/Cluster objects to kubebuilder directives.
+// These can then be copied and pasted into the code.
+type KubebuilderConverter struct {
+	// Rules holds the generated kubebuilder rules
+	Rules []string
+}
+
+// VisitObjects iterates over the provided Role/ClusterRule objects, generating equivalent kubebuilder statements.
+func (c *KubebuilderConverter) VisitObjects(objects []runtime.Object) error {
+	for _, obj := range objects {
+		switch obj := obj.(type) {
+		case *v1.ClusterRole:
+			if err := c.visitRules(obj.Rules, ""); err != nil {
+				return err
+			}
+		case *v1.Role:
+			if err := c.visitRules(obj.Rules, obj.Namespace); err != nil {
+				return err
+			}
+		case *v1.ClusterRoleBinding, *v1.RoleBinding:
+			// Not kubebuilder
+			klog.Infof("ignoring object of type %T for kubebuilder conversion", obj)
+		default:
+			return fmt.Errorf("unhandled type %T", obj)
+		}
+	}
+
+	sort.Strings(c.Rules)
+
+	return nil
+}
+
+// visitRules visits a set of policy rules, generating the equivalent kubebuilder rule
+func (c *KubebuilderConverter) visitRules(rules []v1.PolicyRule, namespace string) error {
+	for _, rule := range rules {
+		def := "//+kubebuilder:rbac:"
+		if len(rule.APIGroups) != 0 {
+			def += "groups=" + strings.Join(rule.APIGroups, ";")
+		}
+		if namespace != "" {
+			def += ",namespace=" + namespace
+		}
+		if len(rule.Resources) != 0 {
+			def += ",resources=" + strings.Join(rule.Resources, ";")
+		}
+		if len(rule.ResourceNames) != 0 {
+			def += ",resourceNames=" + strings.Join(rule.ResourceNames, ";")
+		}
+		if len(rule.Verbs) != 0 {
+			def += ",verbs=" + strings.Join(rule.Verbs, ";")
+		}
+		if len(rule.NonResourceURLs) != 0 {
+			def += ",urls=" + strings.Join(rule.NonResourceURLs, ";")
+		}
+
+		c.Rules = append(c.Rules, def)
+	}
+
+	return nil
+}

--- a/tools/rbac-gen/pkg/convert/ruleset.go
+++ b/tools/rbac-gen/pkg/convert/ruleset.go
@@ -1,0 +1,160 @@
+package convert
+
+import (
+	"sort"
+	"strings"
+
+	v1 "k8s.io/api/rbac/v1"
+)
+
+// ruleSet is a wrapper around a set of PolicyRules, and allows for more fluent construction
+type ruleSet struct {
+	rules []v1.PolicyRule
+}
+
+// Add appends rule(s) to the rules in the set.
+func (r *ruleSet) Add(rules ...v1.PolicyRule) {
+	r.rules = append(r.rules, rules...)
+}
+
+// normalize attempts to simplify and combine redundant rules.
+func (r *ruleSet) normalize() {
+	r.rules = normalizeRules(r.rules)
+
+	r.rules = foldResources(r.rules)
+
+	r.rules = foldVerbs(r.rules)
+
+	sort.Slice(r.rules, func(i, j int) bool { return ruleLT(&r.rules[i], &r.rules[j]) })
+}
+
+// ruleLT is a comparison function for PolicyRule, so we can sort into a consistent order.
+func ruleLT(l, r *v1.PolicyRule) bool {
+	lGroup := firstOrEmpty(l.APIGroups)
+	rGroup := firstOrEmpty(r.APIGroups)
+	if lGroup != rGroup {
+		return lGroup < rGroup
+	}
+	lResource := firstOrEmpty(l.Resources)
+	rResource := firstOrEmpty(r.Resources)
+	if lResource != rResource {
+		return lResource < rResource
+	}
+	lVerb := firstOrEmpty(l.Verbs)
+	rVerb := firstOrEmpty(r.Verbs)
+	if lVerb != rVerb {
+		return lVerb < rVerb
+	}
+	return false
+}
+
+// firstOrEmpty is a utility function for our comparison function.
+func firstOrEmpty(s []string) string {
+	if len(s) == 0 {
+		return ""
+	}
+	return s[0]
+}
+
+// foldResources combines rules that are the same other than in the resource field, so we can join them and concatenate their resources.
+func foldResources(rules []v1.PolicyRule) []v1.PolicyRule {
+	var out []v1.PolicyRule
+
+	ruleMap := make(map[string]v1.PolicyRule)
+
+	for _, rule := range rules {
+		if len(rule.NonResourceURLs) != 0 {
+			out = append(out, rule)
+			continue
+		}
+
+		key := "groups=" + strings.Join(rule.APIGroups, ",")
+		//key += ";resources=" + strings.Join(rule.Resources, ",")
+		key += ";resourceNames=" + strings.Join(rule.ResourceNames, ",")
+		key += ";verbs=" + strings.Join(rule.Verbs, ",")
+
+		existing, found := ruleMap[key]
+		if !found {
+			ruleMap[key] = rule
+			continue
+		}
+
+		existing.Resources = append(existing.Resources, rule.Resources...)
+		sort.Strings(existing.Resources)
+
+		ruleMap[key] = existing
+	}
+
+	for _, rule := range ruleMap {
+		out = append(out, rule)
+	}
+
+	return out
+}
+
+// foldVerbs combines rules that are the same other than in the verbs field, so we can join them and concatenate their verbs.
+func foldVerbs(rules []v1.PolicyRule) []v1.PolicyRule {
+	var out []v1.PolicyRule
+
+	ruleMap := make(map[string]v1.PolicyRule)
+
+	for _, rule := range rules {
+		if len(rule.NonResourceURLs) != 0 {
+			out = append(out, rule)
+			continue
+		}
+
+		key := "groups=" + strings.Join(rule.APIGroups, ",")
+		key += ";resources=" + strings.Join(rule.Resources, ",")
+		key += ";resourceNames=" + strings.Join(rule.ResourceNames, ",")
+		// key += ";verbs=" + strings.Join(rule.Verbs, ",")
+
+		existing, found := ruleMap[key]
+		if !found {
+			ruleMap[key] = rule
+			continue
+		}
+
+		existing.Verbs = append(existing.Verbs, rule.Verbs...)
+		sort.Strings(existing.Verbs)
+
+		ruleMap[key] = existing
+	}
+
+	for _, rule := range ruleMap {
+		out = append(out, rule)
+	}
+
+	return out
+}
+
+// normalizeRules sorts and deduplicates the values within rules, for easier folding and stable output.
+func normalizeRules(rules []v1.PolicyRule) []v1.PolicyRule {
+	for i := range rules {
+		rule := &rules[i]
+
+		rule.APIGroups = normalizeStringSlice(rule.APIGroups)
+		rule.NonResourceURLs = normalizeStringSlice(rule.NonResourceURLs)
+		rule.ResourceNames = normalizeStringSlice(rule.ResourceNames)
+		rule.Resources = normalizeStringSlice(rule.Resources)
+		rule.Verbs = normalizeStringSlice(rule.Verbs)
+	}
+
+	return rules
+}
+
+// normalizeStringSlice deduplicates and sorts a []string
+func normalizeStringSlice(in []string) []string {
+	var out []string
+
+	done := make(map[string]bool)
+	for _, s := range in {
+		if done[s] {
+			continue
+		}
+		out = append(out, s)
+	}
+
+	sort.Strings(out)
+	return out
+}

--- a/tools/rbac-gen/pkg/convert/tests/clusterrole.out.kubebuilder
+++ b/tools/rbac-gen/pkg/convert/tests/clusterrole.out.kubebuilder
@@ -1,0 +1,2 @@
+//+kubebuilder:rbac:groups=,resources=pods;secrets,verbs=get;list;watch
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;roles,verbs=create;delete;get;update

--- a/tools/rbac-gen/pkg/convert/tests/clusterrole.out.yaml
+++ b/tools/rbac-gen/pkg/convert/tests/clusterrole.out.yaml
@@ -3,39 +3,23 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: generated-role
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
   resources:
   - pods
-  verbs:
-  - get
-  - watch
-  - list
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - roles
-  verbs:
-  - create
-  - update
-  - delete
-  - get
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - get
-  - watch
   - list
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterroles
+  - roles
   verbs:
   - create
-  - update
   - delete
   - get
+  - update

--- a/tools/rbac-gen/pkg/convert/tests/duplicates.out.kubebuilder
+++ b/tools/rbac-gen/pkg/convert/tests/duplicates.out.kubebuilder
@@ -1,0 +1,2 @@
+//+kubebuilder:rbac:groups=,resources=configmaps,verbs=create;delete;get;update
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;delete;get;update

--- a/tools/rbac-gen/pkg/convert/tests/duplicates.out.yaml
+++ b/tools/rbac-gen/pkg/convert/tests/duplicates.out.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: generated-role
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -11,15 +10,15 @@ rules:
   - configmaps
   verbs:
   - create
-  - update
   - delete
   - get
+  - update
 - apiGroups:
   - apps
   resources:
   - deployments
   verbs:
   - create
-  - update
   - delete
   - get
+  - update

--- a/tools/rbac-gen/pkg/convert/tests/simple.out.kubebuilder
+++ b/tools/rbac-gen/pkg/convert/tests/simple.out.kubebuilder
@@ -1,0 +1,1 @@
+//+kubebuilder:rbac:groups=,resources=configmaps,verbs=create;delete;get;update

--- a/tools/rbac-gen/pkg/convert/tests/simple.out.yaml
+++ b/tools/rbac-gen/pkg/convert/tests/simple.out.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: generated-role
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -11,6 +10,6 @@ rules:
   - configmaps
   verbs:
   - create
-  - update
   - delete
   - get
+  - update

--- a/tools/rbac-gen/pkg/convert/yaml.go
+++ b/tools/rbac-gen/pkg/convert/yaml.go
@@ -1,0 +1,27 @@
+package convert
+
+import (
+	"bytes"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
+)
+
+// ToYAML convert objects to a YAML multidoc string
+func ToYAML(objects []runtime.Object) ([]byte, error) {
+	var buf bytes.Buffer
+
+	for i, obj := range objects {
+		if i != 0 {
+			buf.WriteString("\n---\n\n")
+		}
+
+		b, err := yaml.Marshal(obj)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(b)
+	}
+
+	return buf.Bytes(), nil
+}


### PR DESCRIPTION
* Can now generate kubebuilder rules
* Can now generate permissions that are scoped to a namespace, or object names.