### PR TITLE
kaml: richer name prefixing

### DIFF
--- a/tools/kaml/go.mod
+++ b/tools/kaml/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/google/go-cmp v0.5.3
 	github.com/spf13/cobra v1.1.1
+	k8s.io/klog/v2 v2.30.0
 	sigs.k8s.io/kustomize/kyaml v0.9.4
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/tools/kaml/go.sum
+++ b/tools/kaml/go.sum
@@ -68,6 +68,8 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
+github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
 github.com/go-openapi/analysis v0.17.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
 github.com/go-openapi/analysis v0.18.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
@@ -424,6 +426,8 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
+k8s.io/klog/v2 v2.30.0 h1:bUO6drIvCIsvZ/XFgfxoGFQU/a4Qkh0iAlvUR7vlHJw=
+k8s.io/klog/v2 v2.30.0/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/kustomize/kyaml v0.9.4 h1:DDuzZtjIzFqp2IPy4DTyCI69Cl3bDgcJODjI6sjF9NY=
 sigs.k8s.io/kustomize/kyaml v0.9.4/go.mod h1:UTm64bSWVdBUA8EQoYCxVOaBQxUdIOr5LKWxA4GNbkw=

--- a/tools/kaml/main.go
+++ b/tools/kaml/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-addons/tools/kaml/pkg/prefix"
 	"sigs.k8s.io/cluster-addons/tools/kaml/pkg/xform/labels"
 )
 
@@ -36,6 +37,8 @@ func BuildRootCommand() *cobra.Command {
 	rootCmd.SilenceErrors = true
 
 	labels.AddRemoveLabelsCommand(rootCmd)
+
+	prefix.AddNamePrefixCommand(rootCmd)
 
 	return rootCmd
 }

--- a/tools/kaml/pkg/prefix/fixup_refs.go
+++ b/tools/kaml/pkg/prefix/fixup_refs.go
@@ -1,0 +1,54 @@
+package prefix
+
+import (
+	"context"
+	"strings"
+
+	"sigs.k8s.io/cluster-addons/tools/kaml/pkg/visitor"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
+)
+
+// fixupRefs fixes references to objects after a rename.
+type fixupRefs struct {
+	visitor.Visitor
+
+	OldName string
+	NewName string
+	Group   string
+	Version string
+	Kind    string
+}
+
+// Run applies the transform.
+func (opt fixupRefs) Run(ctx context.Context, resourceList *framework.ResourceList) error {
+	return visitor.VisitResourceList(resourceList, &opt)
+}
+
+func (opt fixupRefs) VisitMap(ctx *visitor.Context, path visitor.Path, m *visitor.KubeMap) error {
+	if !strings.HasSuffix(string(path), "Ref") {
+		return nil
+	}
+
+	vals, err := m.ExtractStringFields()
+	if err != nil {
+		return err
+	}
+
+	name := vals["name"]
+	if name != opt.OldName {
+		return nil
+	}
+
+	if vals["kind"] != opt.Kind {
+		return nil
+	}
+
+	if vals["apiGroup"] != opt.Group {
+		return nil
+	}
+
+	if err := m.Set("name", opt.NewName); err != nil {
+		return nil
+	}
+	return nil
+}

--- a/tools/kaml/pkg/prefix/name.go
+++ b/tools/kaml/pkg/prefix/name.go
@@ -1,0 +1,90 @@
+package prefix
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-addons/tools/kaml/pkg/visitor"
+	"sigs.k8s.io/cluster-addons/tools/kaml/pkg/xform"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
+)
+
+// NamePrefix describes a transform that adds a prefix to object names.
+type NamePrefix struct {
+	visitor.Visitor
+
+	Prefix string
+	Kinds  []string
+}
+
+// Run applies the transform.
+func (opt NamePrefix) Run(ctx context.Context, resourceList *framework.ResourceList) error {
+	return visitor.VisitResourceList(resourceList, &opt)
+}
+
+func contains(haystack []string, s string) bool {
+	for _, v := range haystack {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}
+
+func (opt NamePrefix) VisitKubeObject(ctx *visitor.Context, obj *visitor.KubeObject) error {
+	kind := obj.GetKind()
+	if len(opt.Kinds) > 0 && !contains(opt.Kinds, kind) {
+		return nil
+	}
+
+	apiVersion := obj.GetAPIVersion()
+	group := ""
+	version := ""
+
+	if strings.Contains(apiVersion, "/") {
+		tokens := strings.Split(apiVersion, "/")
+		if len(tokens) != 2 {
+			return fmt.Errorf("unexpected apiVersion %q", apiVersion)
+		}
+		group = tokens[0]
+		version = tokens[1]
+	} else {
+		version = apiVersion
+	}
+
+	oldName := obj.GetName()
+	newName := opt.Prefix + oldName
+
+	obj.SetName(newName)
+
+	ctx.EnqueueVisitor(&fixupRefs{
+		OldName: oldName,
+		NewName: newName,
+		Group:   group,
+		Version: version,
+		Kind:    kind,
+	})
+	return nil
+}
+
+// AddNamePrefixCommand creates the cobra.Command.
+func AddNamePrefixCommand(parent *cobra.Command) {
+	var opt NamePrefix
+
+	cmd := &cobra.Command{
+		Use: "prefix-name",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return fmt.Errorf("expected <prefix> to be passed")
+			}
+			opt.Prefix = args[0]
+			return xform.RunXform(cmd.Context(), opt.Run)
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&opt.Kinds, "kind", opt.Kinds, "pass to only prefix objects of the specified kind; repeat for multiple kinds")
+
+	parent.AddCommand(cmd)
+}

--- a/tools/kaml/pkg/visitor/accept.go
+++ b/tools/kaml/pkg/visitor/accept.go
@@ -1,0 +1,75 @@
+package visitor
+
+import (
+	"fmt"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func VisitResourceList(resourceList *framework.ResourceList, visitor visitor) error {
+	ctx := &Context{}
+
+	ctx.EnqueueVisitor(visitor)
+
+	return ctx.visitResourceList(resourceList)
+}
+
+func visitNode(ctx *Context, path Path, node *yaml.Node, visitor visitor) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return visitor.VisitScalar(ctx, path, node)
+
+	case yaml.SequenceNode:
+		if err := visitor.VisitSequence(ctx, path, node); err != nil {
+			return err
+		}
+		n := len(node.Content)
+		for i := 0; i < n; i += 2 {
+			v := node.Content[i]
+			childPath := path + "[]"
+			if err := visitNode(ctx, childPath, v, visitor); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	case yaml.MappingNode:
+		if err := visitor.VisitMap(ctx, path, &KubeMap{node: node}); err != nil {
+			return err
+		}
+		n := len(node.Content)
+		if n%2 != 0 {
+			return fmt.Errorf("unexpected content length in MappingNode %v", path)
+		}
+		for i := 0; i < n; i += 2 {
+			k := node.Content[i]
+			ks, ok := AsString(k)
+			if !ok {
+				klog.Warningf("ignorning non-string MappingNode key at %v %v", path, k)
+				continue
+			}
+			childPath := string(path) + "." + ks
+			v := node.Content[i+1]
+			if err := visitNode(ctx, Path(childPath), v, visitor); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("unhandled yaml node kind %v", node.Kind)
+	}
+}
+
+func AsString(n *yaml.Node) (string, bool) {
+	if n.Kind != yaml.ScalarNode {
+		return "", false
+	}
+	if n.Tag == "!!str" || n.Tag == "" {
+		return n.Value, true
+	}
+	klog.Infof("Tag: %v", n.Tag)
+	klog.Infof("Tag: %#v", n)
+	return "", false
+}

--- a/tools/kaml/pkg/visitor/context.go
+++ b/tools/kaml/pkg/visitor/context.go
@@ -1,0 +1,44 @@
+package visitor
+
+import (
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+type Context struct {
+	visitorQueue []visitor
+}
+
+func (c *Context) EnqueueVisitor(visitor visitor) {
+	c.visitorQueue = append(c.visitorQueue, visitor)
+}
+
+func (ctx *Context) visitResourceList(resourceList *framework.ResourceList) error {
+	for len(ctx.visitorQueue) > 0 {
+		visitor := ctx.visitorQueue[0]
+		ctx.visitorQueue = ctx.visitorQueue[1:]
+
+		for _, item := range resourceList.Items {
+			var kubeObject *KubeObject
+			switch item.YNode().Kind {
+			case yaml.MappingNode:
+				m := &KubeMap{node: item.YNode()}
+				kubeObject = &KubeObject{obj: m}
+			default:
+				klog.Warningf("unexpected top-level yaml kind %v", item.YNode().Kind)
+			}
+
+			if kubeObject != nil {
+				if err := visitor.VisitKubeObject(ctx, kubeObject); err != nil {
+					return err
+				}
+			}
+
+			if err := visitNode(ctx, "", item.YNode(), visitor); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/tools/kaml/pkg/visitor/interfaces.go
+++ b/tools/kaml/pkg/visitor/interfaces.go
@@ -1,0 +1,32 @@
+package visitor
+
+import (
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+type visitor interface {
+	VisitSequence(ctx *Context, path Path, node *yaml.Node) error
+	VisitMap(ctx *Context, path Path, node *KubeMap) error
+	VisitScalar(ctx *Context, path Path, node *yaml.Node) error
+
+	VisitKubeObject(ctx *Context, obj *KubeObject) error
+}
+
+type Visitor struct {
+}
+
+func (v *Visitor) VisitSequence(ctx *Context, path Path, node *yaml.Node) error {
+	return nil
+}
+
+func (v *Visitor) VisitScalar(ctx *Context, path Path, node *yaml.Node) error {
+	return nil
+}
+
+func (v *Visitor) VisitMap(ctx *Context, path Path, node *KubeMap) error {
+	return nil
+}
+
+func (v *Visitor) VisitKubeObject(ctx *Context, obj *KubeObject) error {
+	return nil
+}

--- a/tools/kaml/pkg/visitor/kubemap.go
+++ b/tools/kaml/pkg/visitor/kubemap.go
@@ -1,0 +1,152 @@
+package visitor
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+type KubeMap struct {
+	node *yaml.Node
+}
+
+func (m *KubeMap) Node() *yaml.Node {
+	return m.node
+}
+
+func (m *KubeMap) getNode(k string) (*yaml.Node, bool, error) {
+	node := m.node
+
+	n := len(node.Content)
+	if n%2 != 0 {
+		return nil, false, fmt.Errorf("unexpected content length in MappingNode")
+	}
+
+	for i := 0; i < n; i += 2 {
+		kNode := node.Content[i]
+		ks, ok := AsString(kNode)
+		if !ok {
+			continue
+		}
+
+		if ks != k {
+			continue
+		}
+		vNode := node.Content[i+1]
+		return vNode, true, nil
+	}
+
+	return nil, false, nil
+}
+
+func (m *KubeMap) GetStringField(k string) (string, bool, error) {
+	vNode, found, err := m.getNode(k)
+	if !found || err != nil {
+		return "", found, err
+	}
+
+	vs, ok := AsString(vNode)
+	if !ok {
+		return "", true, fmt.Errorf("field was not of type string")
+	}
+	return vs, true, nil
+}
+
+func (m *KubeMap) GetMapField(k string) (*KubeMap, bool, error) {
+	vNode, found, err := m.getNode(k)
+	if !found || err != nil {
+		return nil, found, err
+	}
+
+	v, err := AsKubeMap(vNode)
+	if err != nil {
+		return nil, true, err
+	}
+	return v, true, nil
+}
+
+func (m *KubeMap) ExtractStringFields() (map[string]string, error) {
+	node := m.node
+
+	n := len(node.Content)
+	if n%2 != 0 {
+		return nil, fmt.Errorf("unexpected content length in MappingNode")
+	}
+
+	vals := make(map[string]string)
+
+	for i := 0; i < n; i += 2 {
+		kNode := node.Content[i]
+		ks, ok := AsString(kNode)
+		if !ok {
+			continue
+		}
+
+		vNode := node.Content[i+1]
+		vs, ok := AsString(vNode)
+		if !ok {
+			continue
+		}
+		vals[ks] = vs
+	}
+
+	return vals, nil
+}
+
+func (m *KubeMap) Set(k string, newValue string) error {
+	node := m.node
+
+	n := len(node.Content)
+	if n%2 != 0 {
+		return fmt.Errorf("unexpected content length in MappingNode")
+	}
+
+	for i := 0; i < n; i += 2 {
+		kNode := node.Content[i]
+		vNode := node.Content[i+1]
+		ks, ok := AsString(kNode)
+		if !ok {
+			continue
+		}
+
+		if ks == k {
+			if err := setNode(vNode, newValue); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+
+	var newContent []*yaml.Node
+	for _, v := range node.Content {
+		newContent = append(newContent, v)
+	}
+
+	newContent = append(newContent, newStringNode(k), newStringNode(newValue))
+	m.node.Content = newContent
+	return nil
+}
+
+func setNode(node *yaml.Node, value string) error {
+	*node = yaml.Node{}
+	node.Kind = yaml.ScalarNode
+	node.Value = value
+	return nil
+}
+
+func newStringNode(value string) *yaml.Node {
+	node := &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Value: value,
+	}
+	return node
+}
+
+func AsKubeMap(v *yaml.Node) (*KubeMap, error) {
+	switch v.Kind {
+	case yaml.MappingNode:
+		return &KubeMap{node: v}, nil
+	default:
+		return nil, fmt.Errorf("unexpected kind for Map, expected MappingNode, got %v", v.Kind)
+	}
+}

--- a/tools/kaml/pkg/visitor/kubeobject.go
+++ b/tools/kaml/pkg/visitor/kubeobject.go
@@ -1,0 +1,42 @@
+package visitor
+
+import "fmt"
+
+type KubeObject struct {
+	obj *KubeMap
+}
+
+func (o *KubeObject) GetKind() string {
+	s, _, _ := o.obj.GetStringField("kind")
+	return s
+}
+
+func (o *KubeObject) GetAPIVersion() string {
+	s, _, _ := o.obj.GetStringField("apiVersion")
+	return s
+}
+
+func (o *KubeObject) GetName() string {
+	metadata := o.GetMetadata()
+	if metadata == nil {
+		return ""
+	}
+	s, _, _ := metadata.GetStringField("name")
+	return s
+}
+
+func (o *KubeObject) GetMetadata() *KubeMap {
+	m, _, _ := o.obj.GetMapField("metadata")
+	return m
+}
+
+func (o *KubeObject) SetName(name string) error {
+	metadata := o.GetMetadata()
+	if metadata == nil {
+		return fmt.Errorf("metadata not found")
+	}
+	if err := metadata.Set("name", name); err != nil {
+		return err
+	}
+	return nil
+}

--- a/tools/kaml/pkg/visitor/path.go
+++ b/tools/kaml/pkg/visitor/path.go
@@ -1,0 +1,3 @@
+package visitor
+
+type Path string


### PR DESCRIPTION
We support name prefixing by kind, which is useful for avoiding
conflicts on ClusterRole & ClusterRoleBinding.