### PR TITLE
chore: replace k8s.gcr.io images with registry

### DIFF
--- a/coredns/channels/packages/coredns/1.7.0/deployment.yaml
+++ b/coredns/channels/packages/coredns/1.7.0/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
         - name: coredns
-          image: k8s.gcr.io/coredns:v1.7.0
+          image: registry.k8s.io/coredns/coredns:v1.7.0
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/coredns/channels/packages/coredns/1.8.0/deployment.yaml
+++ b/coredns/channels/packages/coredns/1.8.0/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
         - name: coredns
-          image: k8s.gcr.io/coredns/coredns:v1.8.0
+          image: registry.k8s.io/coredns/coredns:v1.8.0
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/coredns/channels/packages/coredns/1.8.4/deployment.yaml
+++ b/coredns/channels/packages/coredns/1.8.4/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
         - name: coredns
-          image: k8s.gcr.io/coredns/coredns:v1.8.4
+          image: registry.k8s.io/coredns/coredns:v1.8.4
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/coredns/controllers/tests/patches-stable.out.yaml
+++ b/coredns/controllers/tests/patches-stable.out.yaml
@@ -144,7 +144,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5

--- a/coredns/controllers/tests/simple-stable.out.yaml
+++ b/coredns/controllers/tests/simple-stable.out.yaml
@@ -142,7 +142,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5

--- a/dashboard/channels/packages/dashboard/1.10.1/manifest.yaml
+++ b/dashboard/channels/packages/dashboard/1.10.1/manifest.yaml
@@ -109,7 +109,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
+        image: registry.k8s.io/kubernetes-dashboard-amd64:v1.10.1
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/dashboard/channels/packages/dashboard/1.8.3/manifest.yaml
+++ b/dashboard/channels/packages/dashboard/1.8.3/manifest.yaml
@@ -114,7 +114,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.3
+        image: registry.k8s.io/kubernetes-dashboard-amd64:v1.8.3
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/kubeproxy/channels/packages/kubeproxy/1.15.0/manifest.yaml
+++ b/kubeproxy/channels/packages/kubeproxy/1.15.0/manifest.yaml
@@ -53,7 +53,7 @@ spec:
         effect: "NoSchedule"
       containers:
       - name: kube-proxy
-        image: k8s.gcr.io/kube-proxy:v1.15.0
+        image: registry.k8s.io/kube-proxy:v1.15.0
         resources:
           requests:
             cpu: 50m

--- a/kubeproxy/controllers/tests/simple-stable.out.yaml
+++ b/kubeproxy/controllers/tests/simple-stable.out.yaml
@@ -102,7 +102,7 @@ spec:
           value: kubernetes-master
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: k8s.gcr.io/kube-proxy:v1.15.0
+        image: registry.k8s.io/kube-proxy:v1.15.0
         name: kube-proxy
         resources:
           requests:

--- a/metrics-server/channels/packages/metrics-server/0.3.6/manifest.yaml
+++ b/metrics-server/channels/packages/metrics-server/0.3.6/manifest.yaml
@@ -82,7 +82,7 @@ spec:
         emptyDir: {}
       containers:
       - name: metrics-server
-        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
+        image: registry.k8s.io/metrics-server-amd64:v0.3.6
         imagePullPolicy: Always
         volumeMounts:
         - name: tmp-dir

--- a/metrics-server/controllers/tests/patches.out.yaml
+++ b/metrics-server/controllers/tests/patches.out.yaml
@@ -131,7 +131,7 @@ spec:
       - args:
         - --kubelet-insecure-tls
         - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
-        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
+        image: registry.k8s.io/metrics-server-amd64:v0.3.6
         imagePullPolicy: Always
         name: metrics-server
         volumeMounts:

--- a/nodelocaldns/channels/packages/nodelocaldns/1.15.0/manifest.yaml
+++ b/nodelocaldns/channels/packages/nodelocaldns/1.15.0/manifest.yaml
@@ -139,7 +139,7 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: k8s.gcr.io/k8s-dns-node-cache:1.15.13
+        image: registry.k8s.io/k8s-dns-node-cache:1.15.13
         resources:
           requests:
             cpu: 25m

--- a/nodelocaldns/controllers/tests/simple.out.yaml
+++ b/nodelocaldns/controllers/tests/simple.out.yaml
@@ -145,7 +145,7 @@ spec:
         - /etc/Corefile
         - -upstreamsvc
         - kube-dns-upstream
-        image: k8s.gcr.io/k8s-dns-node-cache:1.15.13
+        image: registry.k8s.io/k8s-dns-node-cache:1.15.13
         livenessProbe:
           httpGet:
             host: 169.254.20.10


### PR DESCRIPTION
As per https://github.com/kubernetes/k8s.io/issues/4738 replace the usage of the deprecated k8s.gcr.io registry
Verified the digests for images in both registries match.